### PR TITLE
Stop escaping labels

### DIFF
--- a/src/AdamWathan/Form/Elements/Label.php
+++ b/src/AdamWathan/Form/Elements/Label.php
@@ -22,13 +22,13 @@ class Label extends Element
         $result .= '>';
 
         if ($this->labelBefore) {
-            $result .= $this->escape($this->label);
+            $result .= $this->label;
         }
 
         $result .= $this->renderElement();
 
         if (! $this->labelBefore) {
-            $result .= $this->escape($this->label);
+            $result .= $this->label;
         }
 
         $result .= '</label>';


### PR DESCRIPTION
Not really ideal but this will allow to set html in labels. I don't think we're setting anything to labels from DB so this should still fix the xss issue and make the UI nice again.  